### PR TITLE
Add footer content

### DIFF
--- a/_footer.php
+++ b/_footer.php
@@ -1,6 +1,15 @@
 	</main>
 	<footer class="blue">
-		footer
+		<div class="footer-wrapper">
+			<img src="/img/logo_dsa.png" id="dsa-logo" alt="LOGO: DSA" height="100" width="100" class="footer-logo">
+			<div class="left">New Orleans
+				<div class="left-sub">Democratic Socialists of America</div>
+			</div>
+
+			<div class="right">Copyright 2020 DSA New Orleans
+				<div class="right"><a href="mailto:hello@dsaneworleans.org">hello@dsaneworleans.org</a></div>
+			</div>
+		</div>
 	</footer>
 
 	<script type="text/javascript" src="/js/site.js"></script>

--- a/css/site.css
+++ b/css/site.css
@@ -440,6 +440,38 @@ body:not(.page-home) main {
 				font-size: var(--fs-smaller);
 			}
 
+.footer-wrapper {
+	display: flex;
+	justify-content: space-around;
+	align-items: center;
+}
+
+		.footer-logo {
+			align-self: center;
+			margin-left: 5%
+		}
+
+		.left {
+			flex-grow: 1;
+			font-size: 36pt;
+			font-weight: bold;
+			line-height: .9;
+		}
+
+		.left-sub {
+			flex-grow: 1;
+			font-size: 12pt;
+			vertical-align: top;
+		}
+
+		.right {
+			flex-grow: 0;
+			line-height: 1.2;
+			align-self: center;
+			text-align: right;
+			margin-right: 5%;
+		}
+
 /**** Fix it on Smaller Screens ****/
 @media screen and (max-width: 1024px){
 	nav {


### PR DESCRIPTION
Adds DSA logo and copyright information to footer

Desktop:
![Screen Shot 2020-11-16 at 9 02 38 PM](https://user-images.githubusercontent.com/2008701/99341309-429c5080-284f-11eb-84a4-71579a8f23c5.png)

Mobile is a little messed up, so I'm interested in some tips on fixing:
![Screen Shot 2020-11-16 at 9 05 54 PM](https://user-images.githubusercontent.com/2008701/99341400-68295a00-284f-11eb-9edf-609339cc0ecb.png)

